### PR TITLE
Enable caching Travis build, using release version of stack.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: haskell
 
+sudo: false
+cache:
+  directories:
+  - $HOME/.stack/
+
 before_install:
-  - wget -q -O- http://download.fpcomplete.com/ubuntu/fpco.key | sudo apt-key add -
-  - echo 'deb http://download.fpcomplete.com/ubuntu/precise stable main' | sudo tee /etc/apt/sources.list.d/fpco.list
-  - sudo apt-get update
-  - sudo apt-get install stack -y
+- mkdir -p ~/.local/bin
+- export PATH=~/.local/bin:$PATH
+- travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.1.0/stack-0.1.1.0-x86_64-linux.gz | gunzip > ~/.local/bin/stack
+- chmod a+x ~/.local/bin/stack
 
 install:
-  - stack setup
+  - stack setup --no-terminal
+  - stack build --only-snapshot --no-terminal
 
 script:
-  - stack build
+  - stack build --no-terminal


### PR DESCRIPTION
Switch to using docker containers in Travis CI. This allows the use of
caching, whereby the build artifacts for snapshot dependencies are
cached and reused across builds. This significantly reduces build times.
