### PR TITLE
Mark as deprecated in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Build Status](https://travis-ci.org/haskell-distributed/cloud-haskell.svg?branch=master)](https://travis-ci.org/haskell-distributed/cloud-haskell)
 
+### NB: This Meta-Package is deprecated
+
+In the age of [stack][stack], this meta-package is relatively pointless
+and is no longer being maintained.
+
 [Cloud Haskell][cloud-haskell] is a set of libraries that bring
 Erlang-style concurrency and distribution to Haskell programs.
 


### PR DESCRIPTION
We can probably be more eloquent, but I figured I'd get the ball rolling. My only thought about deprecating the meta-package is that it means perhaps that the platform libraries are even less visible than before, but I suspect community engagement is the solution to that one.

Fixes #17 